### PR TITLE
fix: module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ For release notes please consult the specific releases [here](https://github.com
 ### Installation
 
 ```shell
-go get github.com/Nerzal/gocloak/v13
+go get github.com/certifaction/v14
 ```
 
 ### Importing
 
 ```go
- import "github.com/Nerzal/gocloak/v13"
+ import "github.com/certifaction/v14"
 ```
 
 ### Create New User

--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ For release notes please consult the specific releases [here](https://github.com
 ### Installation
 
 ```shell
-go get github.com/certifaction/v14
+go get github.com/certifaction/gocloak/v14
 ```
 
 ### Importing
 
 ```go
- import "github.com/certifaction/v14"
+ import "github.com/certifaction/gocloak/v14"
 ```
 
 ### Create New User

--- a/client.go
+++ b/client.go
@@ -19,7 +19,7 @@ import (
 	"github.com/segmentio/ksuid"
 	"golang.org/x/mod/semver"
 
-	"github.com/certifaction/v14/pkg/jwx"
+	"github.com/certifaction/gocloak/v14/pkg/jwx"
 )
 
 // GoCloak provides functionalities to talk to Keycloak.

--- a/client.go
+++ b/client.go
@@ -19,7 +19,7 @@ import (
 	"github.com/segmentio/ksuid"
 	"golang.org/x/mod/semver"
 
-	"github.com/Nerzal/gocloak/v13/pkg/jwx"
+	"github.com/certifaction/v14/pkg/jwx"
 )
 
 // GoCloak provides functionalities to talk to Keycloak.

--- a/client_benchmark_test.go
+++ b/client_benchmark_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/certifaction/v14"
+	"github.com/certifaction/gocloak/v14"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/client_benchmark_test.go
+++ b/client_benchmark_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Nerzal/gocloak/v13"
+	"github.com/certifaction/v14"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/client_test.go
+++ b/client_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/pkcs12"
 
-	"github.com/certifaction/v14"
+	"github.com/certifaction/gocloak/v14"
 )
 
 type configAdmin struct {

--- a/client_test.go
+++ b/client_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/pkcs12"
 
-	"github.com/Nerzal/gocloak/v13"
+	"github.com/certifaction/v14"
 )
 
 type configAdmin struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Nerzal/gocloak/v13
+module github.com/certifaction/v14
 
 go 1.25.0
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/certifaction/v14
+module github.com/certifaction/gocloak/v14
 
 go 1.25.0
 

--- a/model_test.go
+++ b/model_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/certifaction/v14"
+	"github.com/certifaction/gocloak/v14"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/model_test.go
+++ b/model_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/Nerzal/gocloak/v13"
+	"github.com/certifaction/v14"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/utils_test.go
+++ b/utils_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/Nerzal/gocloak/v13"
+	"github.com/certifaction/v14"
 )
 
 func TestStringP(t *testing.T) {

--- a/utils_test.go
+++ b/utils_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/certifaction/v14"
+	"github.com/certifaction/gocloak/v14"
 )
 
 func TestStringP(t *testing.T) {


### PR DESCRIPTION
Because we kept the original Nerzal module name.

```
go: github.com/certifaction/gocloak@upgrade (v1.0.0) requires github.com/certifaction/gocloak@v1.0.0: parsing go.mod:
        module declares its path as: github.com/Nerzal/gocloak
                but was required as: github.com/certifaction/gocloak
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Module coordinates updated to v14 across the codebase.
* **Documentation**
  * Installation and import examples updated to reference the new module path/version.
* **Tests**
  * Test and benchmark imports adjusted to use the v14 module so tests run against the updated package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->