### PR TITLE
TDT-528: Add missing ProtocolMappersConfig fields for KC26 mapper subkeys

### DIFF
--- a/model_test.go
+++ b/model_test.go
@@ -345,3 +345,67 @@ func TestStringerOmitEmpty(t *testing.T) {
 		assert.Equal(t, "{}", custom.String())
 	}
 }
+
+func TestProtocolMappersConfig_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	// Server response that exercises the mapper-specific config keys added
+	// alongside the original typed set: introspection.token.claim,
+	// included.custom.audience, the address mapper's user.attribute.*
+	// subfields, and the usersessionmodel-note mapper's user.session.note.
+	// All must survive JSON -> struct -> JSON.
+	original := []byte(`{` +
+		`"access.token.claim":"true",` +
+		`"claim.name":"address",` +
+		`"id.token.claim":"true",` +
+		`"included.custom.audience":"core-api",` +
+		`"introspection.token.claim":"true",` +
+		`"user.attribute.country":"country",` +
+		`"user.attribute.formatted":"formatted",` +
+		`"user.attribute.locality":"locality",` +
+		`"user.attribute.postal_code":"postal_code",` +
+		`"user.attribute.region":"region",` +
+		`"user.attribute.street":"street",` +
+		`"user.session.note":"AUTH_TIME",` +
+		`"userinfo.token.claim":"true"` +
+		`}`)
+
+	var cfg gocloak.ProtocolMappersConfig
+	if err := json.Unmarshal(original, &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// All keys map to typed fields.
+	assert.NotNil(t, cfg.AccessTokenClaim)
+	assert.Equal(t, "true", *cfg.AccessTokenClaim)
+	assert.NotNil(t, cfg.ClaimName)
+	assert.Equal(t, "address", *cfg.ClaimName)
+	assert.NotNil(t, cfg.IDTokenClaim)
+	assert.NotNil(t, cfg.UserinfoTokenClaim)
+	assert.NotNil(t, cfg.IntrospectionTokenClaim)
+	assert.NotNil(t, cfg.IncludedCustomAudience)
+	assert.Equal(t, "core-api", *cfg.IncludedCustomAudience)
+	assert.NotNil(t, cfg.UserSessionNote)
+	assert.Equal(t, "AUTH_TIME", *cfg.UserSessionNote)
+	assert.NotNil(t, cfg.UserAttributeFormatted)
+	assert.Equal(t, "formatted", *cfg.UserAttributeFormatted)
+	assert.NotNil(t, cfg.UserAttributeCountry)
+	assert.NotNil(t, cfg.UserAttributeLocality)
+	assert.NotNil(t, cfg.UserAttributePostalCode)
+	assert.NotNil(t, cfg.UserAttributeRegion)
+	assert.NotNil(t, cfg.UserAttributeStreet)
+
+	// Re-marshal: the JSON content must be identical key-for-key to the input.
+	out, err := json.Marshal(&cfg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got, want map[string]string
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("re-unmarshal: %v", err)
+	}
+	if err := json.Unmarshal(original, &want); err != nil {
+		t.Fatalf("unmarshal expected: %v", err)
+	}
+	assert.Equal(t, want, got)
+}

--- a/models.go
+++ b/models.go
@@ -448,6 +448,7 @@ type ProtocolMappers struct {
 // ProtocolMappersConfig is a config of a protocol mapper
 type ProtocolMappersConfig struct {
 	UserinfoTokenClaim                 *string `json:"userinfo.token.claim,omitempty"`
+	IntrospectionTokenClaim            *string `json:"introspection.token.claim,omitempty"`
 	UserAttribute                      *string `json:"user.attribute,omitempty"`
 	IDTokenClaim                       *string `json:"id.token.claim,omitempty"`
 	AccessTokenClaim                   *string `json:"access.token.claim,omitempty"`
@@ -459,6 +460,7 @@ type ProtocolMappersConfig struct {
 	AggregateAttrs                     *string `json:"aggregate.attrs,omitempty"`
 	UsermodelClientRoleMappingClientID *string `json:"usermodel.clientRoleMapping.clientId,omitempty"`
 	IncludedClientAudience             *string `json:"included.client.audience,omitempty"`
+	IncludedCustomAudience             *string `json:"included.custom.audience,omitempty"`
 	FullPath                           *string `json:"full.path,omitempty"`
 	AttributeName                      *string `json:"attribute.name,omitempty"`
 	AttributeNameFormat                *string `json:"attribute.nameformat,omitempty"`
@@ -466,6 +468,13 @@ type ProtocolMappersConfig struct {
 	Script                             *string `json:"script,omitempty"`
 	AddOrganizationAttributes          *string `json:"addOrganizationAttributes,omitempty"`
 	AddOrganizationId                  *string `json:"addOrganizationId,omitempty"`
+	UserSessionNote                    *string `json:"user.session.note,omitempty"`
+	UserAttributeFormatted             *string `json:"user.attribute.formatted,omitempty"`
+	UserAttributeCountry               *string `json:"user.attribute.country,omitempty"`
+	UserAttributeLocality              *string `json:"user.attribute.locality,omitempty"`
+	UserAttributePostalCode            *string `json:"user.attribute.postal_code,omitempty"`
+	UserAttributeRegion                *string `json:"user.attribute.region,omitempty"`
+	UserAttributeStreet                *string `json:"user.attribute.street,omitempty"`
 }
 
 // Client is a ClientRepresentation


### PR DESCRIPTION
Several Keycloak protocol-mapper plugins emit config keys that ProtocolMappersConfig did not model, so they were silently dropped on the JSON -> struct -> JSON round-trip that gocloak.CreateRealm / CreateClientScope perform on imports rendered from a realm template. Notable casualties:

  - oidc-usersessionmodel-note-mapper: user.session.note (loses the session-note name the mapper reads from, e.g. AUTH_TIME for the standard auth_time claim)
  - oidc-address-mapper: user.attribute.formatted /.country /.locality /.postal_code /.region /.street (loses every per-subfield user attribute mapping)
  - oidc-audience-mapper: included.custom.audience (loses literal audiences set on the mapper)
  - several mappers: introspection.token.claim (loses the introspection endpoint emit flag)

Add these as typed *string fields with their canonical JSON tags so they round-trip naturally. No custom (Un)MarshalJSON needed.

Covered by a new TestProtocolMappersConfig_RoundTrip that decodes a payload mixing the new keys with existing typed ones, asserts every field populated, and verifies re-marshalled output equals the input key-for-key.

## Describe your changes

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have added tests that cover my changes (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended protocol mapper configuration with new optional fields for introspection token claims and user attribute settings, including custom audience, organization details, and address attributes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/certifaction/gocloak/pull/9)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->